### PR TITLE
Use space to separate code block flags

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Quickly build cool CLI apps in Rust.
 
 ## Getting started
 
-**[Read the Getting Started guide!](docs/Readme.md)**
+**[Read the Getting Started guide!](https://killercup.github.io/quicli/)**
 
 ## Thanks
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -23,7 +23,7 @@ Create a new Rust binary project called "head"
 with `cargo new --bin head`.
 You should end up with a `Cargo.toml` that looks like this:
 
-```toml,file=Cargo.toml
+```toml file=Cargo.toml
 [package]
 name = "head"
 version = "0.1.0"
@@ -35,7 +35,7 @@ authors = ["Your Name <your@email.address>"]
 Add _quicli_ as an dependency by adding this line
 to the `Cargo.toml` file:
 
-```toml,file=Cargo.toml
+```toml file=Cargo.toml
 quicli = "0.1"
 ```
 
@@ -43,7 +43,7 @@ To be able to use _all_ the features,
 also add these two goodies
 just below the "quicli" line:
 
-```toml,file=Cargo.toml
+```toml file=Cargo.toml
 structopt = "0.1"
 serde = "1"
 ```
@@ -54,7 +54,7 @@ Now, it's time to get started with writing some Rust!
 Open up your `src/main.rs`.
 Let's import all the good stuff:
 
-```rust,file=src/main.rs
+```rust file=src/main.rs
 #[macro_use] extern crate quicli;
 use quicli::prelude::*;
 ```
@@ -66,7 +66,7 @@ That's it. That's all the imports you should need for now!
 Now, quickly write a cool CLI
 (it's also okay to type slowly):
 
-```rust,file=src/main.rs
+```rust file=src/main.rs
 // Add cool slogan for your app here, e.g.:
 /// Get first n lines of a file
 #[derive(Debug, StructOpt)]
@@ -95,7 +95,7 @@ The next step is the easiest one yet;
 You just have to implement all the features you want to add!
 For now, let's leave it at this:
 
-```rust,file=src/main.rs
+```rust file=src/main.rs
 main!(|args: Cli, log_level: verbosity| {
     let data = read_file(&args.file)?;
     info!("Reading first {} lines of {:?}", args.count, args.file);

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ colors:
 sass:
   style: compressed
 
-markdown: CommonMark
+markdown: CommonMarkGhPages
 plugins:
 - jekyll-readme-index
 - jekyll-optional-front-matter

--- a/docs/commit.md
+++ b/docs/commit.md
@@ -11,7 +11,7 @@ Let's start a new project called "commit-msg-gen":
 
 You'll find a `Cargo.toml` file that contains:
 
-```toml,file=Cargo.toml
+```toml file=Cargo.toml
 [package]
 name = "commit-msg-gen"
 version = "0.1.0"
@@ -23,7 +23,7 @@ authors = ["Your Name <your@email.address>"]
 As always,
 add quicli (as well as structopt and serde) as dependencies:
 
-```toml,file=Cargo.toml
+```toml file=Cargo.toml
 quicli = "0.1"
 structopt = "0.1"
 serde = "1"
@@ -37,7 +37,7 @@ Let's use [reqwest]:
 [whatthecommit.com]: https://whatthecommit.com/
 [reqwest]: https://docs.rs/reqwest
 
-```toml,file=Cargo.toml
+```toml file=Cargo.toml
 reqwest = "0.8"
 ```
 
@@ -46,7 +46,7 @@ reqwest = "0.8"
 To get this party started,
 import our new friends:
 
-```rust,file=src/main.rs
+```rust file=src/main.rs
 extern crate reqwest;
 
 #[macro_use] extern crate quicli;
@@ -62,7 +62,7 @@ How about we go one step further and offer to generate _multiple_ commit message
 Sounds great?
 Let's do this!
 
-```rust,file=src/main.rs
+```rust file=src/main.rs
 /// Get some cool commit messages!
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -129,7 +129,7 @@ We can define our own type that describes the JSON structure:
 
 [`Value`]: https://docs.rs/serde_json/1.0.9/serde_json/enum.Value.html
 
-```rust,file=src/main.rs
+```rust file=src/main.rs
 #[derive(Deserialize)]
 struct Commit {
     commit_message: String,
@@ -153,7 +153,7 @@ Oh, and because it might take a while for the commits to arrive,
 we also write some log output.
 (Use `-vv` to see it!)
 
-```rust,file=src/main.rs
+```rust file=src/main.rs
 main!(|args: Cli, log_level: verbosity| {
     for i in 0..args.amount {
         info!("try {}", i);


### PR DESCRIPTION
This depends on waltz_cli 0.1.3