### PR TITLE
Revert main error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "quicli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicli"
-version = "0.1.3"
+version = "0.1.4"
 description = "Quickly build cool CLI apps in Rust."
 authors = ["Pascal Hertleif <killercup@gmail.com>"]
 readme = "Readme.md"

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.1.3] - 2018-02-01
+## [0.1.4] - 2018-02-09
+
+### Changed
+
+- Reverts "`main!` now uses the more permissive `std::result::Result` enum and `std::error::Error` trait." from 0.1.3 which broke existing code
+
+## [0.1.3] - 2018-02-01 - Yanked!
 
 ### Changed
 

--- a/src/main_macro.rs
+++ b/src/main_macro.rs
@@ -32,7 +32,7 @@
 macro_rules! main {
     (|$args:ident: $cli:ty, log_level: $verbosity:ident| $body:expr) => {
         fn main() {
-            fn run() -> std::result::Result<(), Box<std::error::Error>> {
+            fn run() -> $crate::prelude::Result<()> {
                 let $args = <$cli>::from_args();
                 let log_level = match $args.verbosity {
                     0 => $crate::prelude::LogLevel::Error,
@@ -64,7 +64,7 @@ macro_rules! main {
 
     (|$args:ident: $cli:ty| $body:expr) => {
         fn main() {
-            fn run() -> std::result::Result<(), Box<std::error::Error>> {
+            fn run() -> $crate::prelude::Result<()> {
                 let $args = <$cli>::from_args();
                 $crate::prelude::LoggerBuiler::new()
                     .filter(Some(env!("CARGO_PKG_NAME")), $crate::prelude::LogLevel::Error.to_level_filter())
@@ -90,7 +90,7 @@ macro_rules! main {
 
     ($body:expr) => {
         fn main() {
-            fn run() -> std::result::Result<(), Box<std::error::Error>> {
+            fn run() -> $crate::prelude::Result<()> {
                 $crate::prelude::LoggerBuiler::new()
                     .filter(Some(env!("CARGO_PKG_NAME")), $crate::prelude::LogLevel::Error.to_level_filter())
                     .filter(None, $crate::prelude::LogLevel::Warn.to_level_filter())


### PR DESCRIPTION
Seems like what I had in mind in #31 didn't work: It breaks failure's macros and with it the waltz_cli crate. This reverts #32. I'll publish 0.1.4 if this is green (I've yanked 0.1.3).