### PR TITLE
fix #43: pub use crates, add set_log_verbosity and feature=full-throttle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,32 @@ keywords = ["cli", "prelude"]
 [dependencies]
 failure = "0.1.1"
 failure_derive = "0.1.1"
-serde = "1.0.27"
-serde_derive = "1.0.27"
 structopt = "0.1.6"
 structopt-derive = "0.1.6"
 log = "0.4.1"
 env_logger = "0.5.3"
-glob = "0.2.11"
-rayon = "0.9.0"
+
+[dependencies.serde]
+version = "1.0.27"
+optional = true
+
+[dependencies.serde_derive]
+version = "1.0.27"
+optional = true
+
+[dependencies.glob]
+version = "0.2.11"
+optional = true
+
+[dependencies.rayon]
+version = "0.9.0"
+optional = true
+
+[features]
+default = ["full-throttle"]
+full-throttle = [
+    "serde",
+    "serde_derive",
+    "glob",
+    "rayon",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,10 @@ structopt = "0.1.6"
 structopt-derive = "0.1.6"
 log = "0.4.1"
 env_logger = "0.5.3"
-
-[dependencies.serde]
-version = "1.0.27"
-optional = true
-
-[dependencies.serde_derive]
-version = "1.0.27"
-optional = true
-
-[dependencies.glob]
-version = "0.2.11"
-optional = true
-
-[dependencies.rayon]
-version = "0.9.0"
-optional = true
+serde = {version = "1.0.27", optional = true}
+serde_derive = {version = "1.0.27", optional = true}
+glob = {version = "0.2.11", optional = true}
+rayon = {version = "0.9.0", optional = true}
 
 [features]
 default = ["full-throttle"]

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -65,7 +65,7 @@ Let's import all the good stuff:
 #[macro_use] extern crate quicli;
 use quicli::prelude::*;
 ```
- 
+
 That's it. That's all the imports you should need for now!
 
 ## Write a CLI struct
@@ -138,7 +138,7 @@ main!(|args: Cli, log_level: verbosity| {
     let content = read_file(&args.file)?;
     let content_lines = content.lines();
     let first_n_lines = content_lines.take(args.count);
-    
+
     info!("Reading first {} lines of {:?}", args.count, args.file);
 
     for line in first_n_lines {

--- a/src/easy_log.rs
+++ b/src/easy_log.rs
@@ -1,0 +1,28 @@
+use super::prelude;
+
+/// Set the logs verbosity based on an integer value:
+///
+/// - `0`: error
+/// - `1`: warn
+/// - `2`: info
+/// - `3`: debug
+/// - `>=4`: trace
+///
+/// This is used in the [`main!`] macro. You should typically use that instead.
+///
+/// [`main!`]: macro.main.html
+pub fn set_log_verbosity(verbosity: u64) -> prelude::Result<()> {
+    let log_level = match verbosity {
+        0 => prelude::LogLevel::Error,
+        1 => prelude::LogLevel::Warn,
+        2 => prelude::LogLevel::Info,
+        3 => prelude::LogLevel::Debug,
+        _ => prelude::LogLevel::Trace,
+    }.to_level_filter();
+
+    prelude::LoggerBuiler::new()
+        .filter(Some(env!("CARGO_PKG_NAME")), log_level)
+        .filter(None, prelude::LogLevel::Warn.to_level_filter())
+        .try_init()?;
+    Ok(())
+}

--- a/src/easy_log.rs
+++ b/src/easy_log.rs
@@ -8,9 +8,11 @@ use super::prelude;
 /// - `3`: debug
 /// - `>=4`: trace
 ///
-/// This is used in the [`main!`] macro. You should typically use that instead.
+/// This is used in the [`main!`] macro. This function is _not_ stabilized and should
+/// not (yet) be used directly. See
 ///
 /// [`main!`]: macro.main.html
+#[doc(hidden)]
 pub fn set_log_verbosity(verbosity: u64) -> prelude::Result<()> {
     let log_level = match verbosity {
         0 => prelude::LogLevel::Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,22 +8,22 @@
 
 #[cfg(feature="full-throttle")]
 #[macro_use]
-pub extern crate serde_derive;
+extern crate serde_derive;
 #[cfg(feature="full-throttle")]
-pub extern crate serde;
+extern crate serde;
 
 #[macro_use]
-pub extern crate structopt_derive;
-pub extern crate structopt;
+extern crate structopt_derive;
+extern crate structopt;
 
 #[macro_use] extern crate failure_derive;
 #[macro_use] extern crate failure;
 
-#[macro_use] pub extern crate log;
-pub extern crate env_logger;
+#[macro_use] extern crate log;
+extern crate env_logger;
 
 #[cfg(feature="full-throttle")]
-pub extern crate rayon;
+extern crate rayon;
 
 #[cfg(feature="full-throttle")]
 pub mod fs;
@@ -36,7 +36,10 @@ mod reexports {
     #[doc(hidden)] pub use serde_derive::*;
 
     #[doc(hidden)] pub use structopt_derive::*;
-    #[doc(hidden)] pub use structopt::{self, StructOpt};
+    #[doc(hidden)] pub mod structopt {
+        pub use ::structopt::*;
+    }
+    #[doc(hidden)] pub use structopt::StructOpt;
 
     #[doc(hidden)] pub use failure_derive::*;
     #[doc(hidden)] pub use failure::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,38 +6,47 @@
 #![allow(unused_imports)]
 #![deny(missing_docs)]
 
-#[macro_use] extern crate serde_derive;
-extern crate serde;
+#[cfg(feature="full-throttle")]
+#[macro_use]
+pub extern crate serde_derive;
+#[cfg(feature="full-throttle")]
+pub extern crate serde;
 
-#[macro_use] extern crate structopt_derive;
-extern crate structopt;
+#[macro_use]
+pub extern crate structopt_derive;
+pub extern crate structopt;
 
 #[macro_use] extern crate failure_derive;
 #[macro_use] extern crate failure;
 
-#[macro_use] extern crate log;
-extern crate env_logger;
+#[macro_use] pub extern crate log;
+pub extern crate env_logger;
 
-extern crate rayon;
+#[cfg(feature="full-throttle")]
+pub extern crate rayon;
 
+#[cfg(feature="full-throttle")]
 pub mod fs;
 mod main_macro;
+mod easy_log;
+pub use easy_log::set_log_verbosity;
 
 mod reexports {
+    #[cfg(feature="full-throttle")]
     #[doc(hidden)] pub use serde_derive::*;
 
     #[doc(hidden)] pub use structopt_derive::*;
-    #[doc(hidden)] pub mod structopt {
-        pub use ::structopt::*;
-    }
-    #[doc(hidden)] pub use structopt::StructOpt;
+    #[doc(hidden)] pub use structopt::{self, StructOpt};
 
     #[doc(hidden)] pub use failure_derive::*;
     #[doc(hidden)] pub use failure::*;
 
     #[doc(hidden)] pub use log::*;
 
+    #[cfg(feature="full-throttle")]
     pub use rayon::prelude::*;
+
+   pub use super::set_log_verbosity;
 }
 
 /// Prelude – import all of this
@@ -53,6 +62,7 @@ pub mod prelude {
     /// A handy alias for `Result` that carries a generic error type.
     pub type Result<T> = ::std::result::Result<T, ::failure::Error>;
 
+    #[cfg(feature="full-throttle")]
     pub use fs::*;
 
     #[doc(hidden)] pub use env_logger::Builder as LoggerBuiler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ extern crate rayon;
 #[cfg(feature="full-throttle")]
 pub mod fs;
 mod main_macro;
-mod easy_log;
+#[doc(hidden)]
+pub mod easy_log;
 pub use easy_log::set_log_verbosity;
 
 mod reexports {

--- a/src/main_macro.rs
+++ b/src/main_macro.rs
@@ -34,18 +34,7 @@ macro_rules! main {
         fn main() {
             fn run() -> $crate::prelude::Result<()> {
                 let $args = <$cli>::from_args();
-                let log_level = match $args.$verbosity {
-                    0 => $crate::prelude::LogLevel::Error,
-                    1 => $crate::prelude::LogLevel::Warn,
-                    2 => $crate::prelude::LogLevel::Info,
-                    3 => $crate::prelude::LogLevel::Debug,
-                    _ => $crate::prelude::LogLevel::Trace,
-                }.to_level_filter();
-
-                $crate::prelude::LoggerBuiler::new()
-                    .filter(Some(env!("CARGO_PKG_NAME")), log_level)
-                    .filter(None, $crate::prelude::LogLevel::Warn.to_level_filter())
-                    .try_init()?;
+                $crate::prelude::set_log_verbosity($args.$verbosity)?;
 
                 $body
 
@@ -66,10 +55,7 @@ macro_rules! main {
         fn main() {
             fn run() -> $crate::prelude::Result<()> {
                 let $args = <$cli>::from_args();
-                $crate::prelude::LoggerBuiler::new()
-                    .filter(Some(env!("CARGO_PKG_NAME")), $crate::prelude::LogLevel::Error.to_level_filter())
-                    .filter(None, $crate::prelude::LogLevel::Warn.to_level_filter())
-                    .try_init()?;
+                $crate::prelude::set_log_verbosity(0)?; // ERROR level verbosity
 
                 $body
 
@@ -91,10 +77,7 @@ macro_rules! main {
     ($body:expr) => {
         fn main() {
             fn run() -> $crate::prelude::Result<()> {
-                $crate::prelude::LoggerBuiler::new()
-                    .filter(Some(env!("CARGO_PKG_NAME")), $crate::prelude::LogLevel::Error.to_level_filter())
-                    .filter(None, $crate::prelude::LogLevel::Warn.to_level_filter())
-                    .try_init()?;
+                $crate::prelude::set_log_verbosity(0)?; // ERROR level verbosity
 
                 $body
                 Ok(())

--- a/src/main_macro.rs
+++ b/src/main_macro.rs
@@ -34,7 +34,7 @@ macro_rules! main {
         fn main() {
             fn run() -> $crate::prelude::Result<()> {
                 let $args = <$cli>::from_args();
-                $crate::prelude::set_log_verbosity($args.$verbosity)?;
+                $crate::easy_log::set_log_verbosity($args.$verbosity)?;
 
                 $body
 
@@ -55,7 +55,7 @@ macro_rules! main {
         fn main() {
             fn run() -> $crate::prelude::Result<()> {
                 let $args = <$cli>::from_args();
-                $crate::prelude::set_log_verbosity(0)?; // ERROR level verbosity
+                $crate::easy_log::set_log_verbosity(0)?; // ERROR level verbosity
 
                 $body
 
@@ -77,7 +77,7 @@ macro_rules! main {
     ($body:expr) => {
         fn main() {
             fn run() -> $crate::prelude::Result<()> {
-                $crate::prelude::set_log_verbosity(0)?; // ERROR level verbosity
+                $crate::easy_log::set_log_verbosity(0)?; // ERROR level verbosity
 
                 $body
                 Ok(())


### PR DESCRIPTION
This does several things to, some of which is to integrate better with the `ergo` ecosystem.

- Adds `feature=full-throttle` as suggested in #43, which allows disabling some of the included crates
- Moves `set_log_verbosity` into a function so that users can more cleanly migrate away from the `main!` macro (I already had need of this in `artifact`).
- Publically uses crates to improve the import story. For instance, to use `clap` (which is exported by `quicli`), I had to do: `use quicli::prelude::structopt::clap`, which now I can do `use quicli::structopt::clap`.

I am currently using both `ergo` and `quicli` together to rewrite `artifact`'s CLI. I'll keep opening bugs/PRs as I find them!