### PR TITLE
Remove failure rexports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ extern crate serde;
 #[macro_use] extern crate structopt_derive;
 extern crate structopt;
 
-#[macro_use] extern crate failure_derive;
 #[macro_use] extern crate failure;
 
 #[macro_use] extern crate log;
@@ -31,9 +30,6 @@ mod reexports {
         pub use ::structopt::*;
     }
     #[doc(hidden)] pub use structopt::StructOpt;
-
-    #[doc(hidden)] pub use failure_derive::*;
-    #[doc(hidden)] pub use failure::*;
 
     #[doc(hidden)] pub use log::*;
 


### PR DESCRIPTION
Based on what I found in https://github.com/studio-lucia/sss_fontbuild/pull/2, it looks like it's not possible to use the `failure`/`failure_derive` reexports from the prelude; it seems to be necessary to independently import those crates anyway. As a result, there doesn't seem to really be a reason to reexport them.

I also removed the `failure_derive` import in this module, since it's not used internally either.