### PR TITLE
Fix verbosity for hyphenated package names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - The full code of the example projects from the guides is now also available in
   the repository's [`examples/`] directory.
-  
+
 [`examples/`]: https://github.com/killercup/quicli/tree/master/examples
+
+### Fixed
+
+- Verbosity flag works for hyphenated package names
 
 ### Changed
 

--- a/src/main_macro.rs
+++ b/src/main_macro.rs
@@ -44,7 +44,7 @@ macro_rules! main {
                 }.to_level_filter();
 
                 $crate::prelude::LoggerBuilder::new()
-                    .filter(Some(env!("CARGO_PKG_NAME")), log_level)
+                    .filter(Some(&env!("CARGO_PKG_NAME").replace("-", "_")), log_level)
                     .filter(None, $crate::prelude::LogLevel::Warn.to_level_filter())
                     .try_init()?;
 
@@ -68,7 +68,7 @@ macro_rules! main {
             fn run() -> $crate::prelude::Result<()> {
                 let $args = <$cli>::from_args();
                 $crate::prelude::LoggerBuilder::new()
-                    .filter(Some(env!("CARGO_PKG_NAME")), $crate::prelude::LogLevel::Error.to_level_filter())
+                    .filter(Some(&env!("CARGO_PKG_NAME").replace("-", "_")), $crate::prelude::LogLevel::Error.to_level_filter())
                     .filter(None, $crate::prelude::LogLevel::Warn.to_level_filter())
                     .try_init()?;
 
@@ -93,7 +93,7 @@ macro_rules! main {
         fn main() {
             fn run() -> $crate::prelude::Result<()> {
                 $crate::prelude::LoggerBuilder::new()
-                    .filter(Some(env!("CARGO_PKG_NAME")), $crate::prelude::LogLevel::Error.to_level_filter())
+                    .filter(Some(&env!("CARGO_PKG_NAME").replace("-", "_")), $crate::prelude::LogLevel::Error.to_level_filter())
                     .filter(None, $crate::prelude::LogLevel::Warn.to_level_filter())
                     .try_init()?;
 


### PR DESCRIPTION
`env_logger` expects to filter on module names, and these replace hyphens with
underscores.  For logging to work for such packages, we make the same
transformation.

Fixes #60.