### PR TITLE
Update link to Structopt in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ This is only possible because of all the awesome libraries included here:
 - [failure] for ergonomic error handling.
 - …and more to come!
 
-[Structopt]: https://docs.rs/structopt-derive
+[Structopt]: https://docs.rs/structopt
 [Clap]: https://clap.rs/
 [Serde]: https://serde.rs/
 [failure]: https://boats.gitlab.io/failure/


### PR DESCRIPTION
Just noticed by chance that the current link to Structopt doesn't seem to point to anything meaningful. This one should work better.