### PR TITLE
replace Error::causes() by iter_causes()

### DIFF
--- a/src/main_macro.rs
+++ b/src/main_macro.rs
@@ -68,7 +68,7 @@ macro_rules! main {
 
             if let Err(e) = run() {
                 eprintln!("error: {}", e);
-                for cause in e.causes().skip(1) {
+                for cause in e.iter_causes() {
                     eprintln!("caused by: {}", cause);
                 }
                 ::std::process::exit(1);
@@ -92,7 +92,7 @@ macro_rules! main {
 
             if let Err(e) = run() {
                 eprintln!("error: {}", e);
-                for cause in e.causes().skip(1) {
+                for cause in e.iter_causes() {
                     eprintln!("caused by: {}", cause);
                 }
                 ::std::process::exit(1);


### PR DESCRIPTION
This might complete PR #88 for `main` macro in cases: `main!(|args: Arg|{...})` and `main!(||{...})`.