### PR TITLE
Expose remove_dir_all from crate with same name instead of std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,7 @@ dependencies = [
  "globwalk 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "0.5.3"
 globwalk = { version = "0.3", optional = true }
 rayon = { version = "1.0", optional = true }
 clap-verbosity-flag = "0.1.0"
+remove_dir_all = { version = "0.5.1", optional = true}
 
 [dev-dependencies]
 tempfile = "3.0.3"
@@ -33,6 +34,7 @@ full-throttle = [
     "serde_derive",
     "globwalk",
     "rayon",
+    "remove_dir_all"
 ]
 
 [workspace]

--- a/docs/thumbnails.md
+++ b/docs/thumbnails.md
@@ -117,6 +117,14 @@ Let's also add an option to specify _where_ to save those thumbnails!
     thumb_dir: String,
 ```
 
+And a flag to specify wether we want to clean it before creating our thumbnails!
+
+``` rust file=src/main.rs
+    /// Should we clean the output directory?
+    #[structopt(long="clean-dir")]
+    clean_dir: bool,
+```
+
 There we go.
 Oh, wait, let's not forget to close that struct definition:
 
@@ -146,13 +154,22 @@ gives you a list of all the file paths that match the pattern.
     let files = glob(&args.pattern)?;
 ```
 
-And, while we are at it,
-let's also create the output directory
-if it doesn't exist yet
+Before creating any of the thumbnails, let's clean-up the output directory,
+if requested by the caller.
+_quicli_ provides `remove_dir_all` to clean any directory tree you'd like!
+
+```rust file=src/main.rs
+    let thumb_dir = std::path::Path::new(&args.thumb_dir);
+    if args.clean_dir && thumb_dir.exists() {
+        remove_dir_all(&thumb_dir)?;
+    }
+```
+
+Now we're ready to (re)create the output directory.
 (another function _quicli_ gives you):
 
 ```rust file=src/main.rs
-    create_dir(&args.thumb_dir)?;
+    create_dir(&thumb_dir)?;
 ```
 
 Great, that was the first step.

--- a/examples/thumbnails/src/main.rs
+++ b/examples/thumbnails/src/main.rs
@@ -15,11 +15,10 @@ struct Cli {
     /// Where do you want to save the thumbnails?
     #[structopt(long = "output", short = "o", default_value = "thumbnails")]
     thumb_dir: String,
-
+    /// Should we clean the output directory?
     #[structopt(long="clean-dir")]
     clean_dir: bool,
 }
-
 main!(|args: Cli, log_level: verbosity| {
     let files = glob(&args.pattern)?;
     let thumb_dir = std::path::Path::new(&args.thumb_dir);

--- a/examples/thumbnails/src/main.rs
+++ b/examples/thumbnails/src/main.rs
@@ -15,10 +15,18 @@ struct Cli {
     /// Where do you want to save the thumbnails?
     #[structopt(long = "output", short = "o", default_value = "thumbnails")]
     thumb_dir: String,
+
+    #[structopt(long="clean-dir")]
+    clean_dir: bool,
 }
+
 main!(|args: Cli, log_level: verbosity| {
     let files = glob(&args.pattern)?;
-    create_dir(&args.thumb_dir)?;
+    let thumb_dir = std::path::Path::new(&args.thumb_dir);
+    if args.clean_dir && thumb_dir.exists() {
+        remove_dir_all(&thumb_dir)?;
+    }
+    create_dir(&thumb_dir)?;
     info!("Saving {} thumbnails into {:?}...", files.len(), args.thumb_dir);
 use std::path::Path;
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -4,6 +4,7 @@
 //! tasks. Also, they have great error messages.
 
 extern crate globwalk;
+extern crate remove_dir_all;
 
 use std::path::{Path, PathBuf};
 use std::io::{BufReader, BufWriter, Read, Write};
@@ -15,6 +16,7 @@ use failure::{Error, ResultExt};
 use prelude::Result;
 
 pub use std::fs::create_dir_all as create_dir;
+pub use self::remove_dir_all::remove_dir_all;
 
 /// Read file content into string
 ///


### PR DESCRIPTION
Before anything else, thanks for this very neat crate! 
With the logging, failure and struct-opt ready for use, it makes it really fast to start building quick and clean scripts.
So thanks :)

This PR aims at implementing #85 