### PR TITLE
fix docs for commit example to remove `main!`

### DIFF
--- a/docs/commit.md
+++ b/docs/commit.md
@@ -152,7 +152,7 @@ We don't have to care about those right now.
 
 Nice!
 Now, with that out of the way,
-let's write the typical `main!` macro,
+let's write the typical `main` function,
 but this time with a loop
 in which we request some wonderful commits,
 and print them.


### PR DESCRIPTION
I noticed last night as I was going through the getting started tutorials that the commit example still said `main!` instead of just `main`. Feel free to edit and rewrite in your own voice if you want.